### PR TITLE
[FEAT] 탈퇴했던 email로 재가입 가능

### DIFF
--- a/src/modules/users/services/signin.service.ts
+++ b/src/modules/users/services/signin.service.ts
@@ -9,7 +9,7 @@ export class SignInService {
 
   async saveToken(email: string, access_token: string) {
     const updatedUser = await this.userModel.findOneAndUpdate(
-      { email: email },
+      { email: email, is_deleted: false },
       { access_token: access_token },
       { new: true },
     );

--- a/src/modules/users/services/signup.service.ts
+++ b/src/modules/users/services/signup.service.ts
@@ -46,14 +46,28 @@ export class SignUpService {
     return response.data.kakao_account.email;
   }
 
-  async emailCheck(email: string): Promise<boolean> {
-    const result = await this.userModel.findOne({ email }).exec();
+  async nicknameCheck(email: string, nickname: string): Promise<boolean> {
+    const result = await this.userModel
+      .findOne({ email: { $ne: email }, nickname })
+      .exec();
     return !!result;
   }
 
-  async nicknameCheck(nickname: string): Promise<boolean> {
-    const result = await this.userModel.findOne({ nickname }).exec();
-    return !!result;
+  async emailCheck(email: string): Promise<Number> {
+    const result1 = await this.userModel
+      .findOne({ email, is_deleted: false })
+      .exec();
+    if (!!result1) {
+      return 0;
+    }
+    const result2 = await this.userModel
+      .findOne({ email, is_deleted: true })
+      .exec();
+    if (!!result2) {
+      return 2;
+    } else {
+      return 1;
+    }
   }
 
   async uploadImage(profileImage: Express.Multer.File) {
@@ -81,5 +95,25 @@ export class SignUpService {
       likes: [],
     });
     return newUser.save();
+  }
+
+  async updateUser(
+    email: string,
+    nickname: string,
+    introduce: string,
+    image: string,
+    access_token: string,
+  ) {
+    return await this.userModel.findOneAndUpdate(
+      { email },
+      {
+        nickname,
+        introduce,
+        profile_image: image,
+        access_token,
+        is_deleted: false,
+      },
+      { new: true },
+    );
   }
 }

--- a/src/modules/users/services/update-user.service.ts
+++ b/src/modules/users/services/update-user.service.ts
@@ -19,4 +19,11 @@ export class UpdateUserService {
       { new: true },
     );
   }
+
+  async nicknameCheck(id: string, nickname: string): Promise<boolean> {
+    const result = await this.userModel
+      .findOne({ _id: { $ne: id }, nickname })
+      .exec();
+    return !!result;
+  }
 }

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -26,6 +26,7 @@ import {
 import { AuthGuard } from '@auth/auth.guard';
 import { Request, Response } from 'express';
 import { AuthService } from '@auth/auth.service';
+import { User } from './schemas';
 
 @Controller('users')
 export class UsersController {
@@ -52,12 +53,11 @@ export class UsersController {
     @Res({ passthrough: true }) res: Response,
   ) {
     const { email, access_token } = await this.signUpService.getKakaoUser(code);
-    const emailCheck = await this.signUpService.emailCheck(email);
-    if (!emailCheck) {
-      throw new NotFoundException('존재하지 않는 사용자입니다');
-    }
 
     const updatedUser = await this.signInService.saveToken(email, access_token);
+    if (!updatedUser) {
+      throw new NotFoundException('존재하지 않는 사용자입니다');
+    }
 
     // 쿠키 생성
     const { accessToken } = await this.authService.getJwtToken(
@@ -92,28 +92,43 @@ export class UsersController {
     @Body() createUserDto: CreateUserDto,
     @Res({ passthrough: true }) res: Response,
   ) {
-    const { code, nickname } = createUserDto;
+    const { nickname, introduce, code } = createUserDto;
 
-    const nicknameCheck = await this.signUpService.nicknameCheck(nickname);
+    const { email, access_token } = await this.signUpService.getKakaoUser(code);
+
+    const nicknameCheck = await this.signUpService.nicknameCheck(
+      email,
+      nickname,
+    );
     if (nicknameCheck) {
       throw new ConflictException('이미 사용하고 있는 닉네임입니다');
     }
 
-    const { email, access_token } = await this.signUpService.getKakaoUser(code);
-
     const emailCheck = await this.signUpService.emailCheck(email);
-    if (emailCheck) {
+    if (emailCheck === 0) {
       throw new ConflictException('이미 존재하는 사용자입니다');
     }
 
     const image = await this.signUpService.uploadImage(profile_image);
 
-    const updatedUser = await this.signUpService.createUser(
-      email,
-      image,
-      access_token,
-      createUserDto,
-    );
+    let updatedUser: User;
+
+    if (emailCheck === 1) {
+      updatedUser = await this.signUpService.createUser(
+        email,
+        image,
+        access_token,
+        createUserDto,
+      );
+    } else {
+      updatedUser = await this.signUpService.updateUser(
+        email,
+        nickname,
+        introduce,
+        image,
+        access_token,
+      );
+    }
 
     // 쿠키 생성
     const { accessToken } = await this.authService.getJwtToken(
@@ -164,7 +179,10 @@ export class UsersController {
     const { nickname, introduce } = updateUserDto;
     const id = req.user.userId;
 
-    const nicknameCheck = await this.signUpService.nicknameCheck(nickname);
+    const nicknameCheck = await this.updateUserService.nicknameCheck(
+      id,
+      nickname,
+    );
     if (nicknameCheck) {
       throw new ConflictException('이미 사용하고 있는 닉네임입니다');
     }


### PR DESCRIPTION
## 🔍 PR 개요
회원 탈퇴시 유저 정보를 계속 유지하게 되어 탈퇴한 회원에 대한 3가지 API 수정

## ✨ PR Type
<!--해당 항목에 X를 추가하세요.-->

- [x] 기능 구현(feat)
- [ ] 버그 수정(bugfix)
- [ ] 코드 스타일 변경(가독성 향상)
- [ ] 리팩토링(성능 최적화, 모듈화, 중복 코드 제거 등)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] 기타:

## 📋 변경 사항
- 로그인 API 수정
- 회원가입 API 수정
- 회원 정보 수정 API 수정

## 🛠 상세 작업 내역
- [x] 로그인 API 수정
- [x] 회원가입 API 수정
- [x] 회원 정보 수정 API 수정
## ✅ 체크리스트
- [x] API 테스트

## 📸 스크린샷 (선택 사항)
x

## ⚠️ 주의 사항
x

## 🔗 관련 이슈
- 관련된 이슈 번호 #32
