### PR TITLE
[FEAT] 레시피 수정 API 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "cookie-parser": "^1.4.7",
+    "crypto": "^1.0.1",
     "express": "^4.21.1",
     "mongoose": "^8.7.3",
     "multer": "^1.4.5-lts.1",
     "multer-s3": "^3.0.1",
     "reflect-metadata": "^0.2.0",
-    "rxjs": "^7.8.1",
-    "uuid": "^11.0.2"
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/src/modules/recipes/dto/create-recipe.dto.ts
+++ b/src/modules/recipes/dto/create-recipe.dto.ts
@@ -33,3 +33,7 @@ export class ReqRecipeDto {
 export class CreateRecipeDto extends ReqRecipeDto {
   thumbnail: Express.Multer.File;
 }
+
+export class EditRecipeDto extends ReqRecipeDto {
+  thumbnail?: Express.Multer.File;
+}

--- a/src/modules/recipes/dto/index.ts
+++ b/src/modules/recipes/dto/index.ts
@@ -1,0 +1,3 @@
+export * from './get-recipes.dto';
+export * from './res-recipes.dto';
+export * from './create-recipe.dto';

--- a/src/modules/recipes/recipes.controller.ts
+++ b/src/modules/recipes/recipes.controller.ts
@@ -2,7 +2,9 @@ import {
   Body,
   Controller,
   Get,
+  Param,
   Post,
+  Put,
   Query,
   UploadedFile,
   UseGuards,
@@ -14,7 +16,11 @@ import { RecipesService } from './recipes.service';
 import { UserId, UserIdParam } from '@common/decorators';
 import { RecipeDocument } from './schema/recipe.schema';
 import { GetRecipesDto, SearchRecipesDto } from './dto/get-recipes.dto';
-import { CreateRecipeDto, ReqRecipeDto } from './dto/create-recipe.dto';
+import {
+  CreateRecipeDto,
+  EditRecipeDto,
+  ReqRecipeDto,
+} from './dto/create-recipe.dto';
 
 @Controller('recipes')
 export class RecipesController {
@@ -48,6 +54,21 @@ export class RecipesController {
     )) as RecipeDocument;
 
     await this.recipesService.addPreviewRecipe(createdRecipe);
+    return;
+  }
+
+  // 레시피 수정
+  @UseGuards(AuthGuard)
+  @UseInterceptors(FileInterceptor('thumbnail'))
+  @Put(':recipe_id')
+  async editRecipe(
+    @UserIdParam() userId: UserId,
+    @Param('recipe_id') recipeId: string,
+    @UploadedFile() thumbnail: Express.Multer.File,
+    @Body() data: ReqRecipeDto,
+  ) {
+    const recipeData: EditRecipeDto = { ...data, thumbnail };
+    await this.recipesService.updateRecipe(userId, recipeId, recipeData);
     return;
   }
 }

--- a/src/modules/recipes/recipes.repository.ts
+++ b/src/modules/recipes/recipes.repository.ts
@@ -1,10 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, SortOrder, Types } from 'mongoose';
 import { RecipePreview } from './schema/recipe-preview.schema';
 import { Recipe } from './schema/recipe.schema';
 import { User } from '@modules/users/schemas';
 import { WriterDto } from './dto/res-recipes.dto';
+import { EditRecipeDto } from './dto';
 
 export interface RecipeRepository {
   filteredRecipes(
@@ -78,5 +79,49 @@ export class RecipeMongoRepository implements RecipeRepository {
 
   async insertPreview(recipes: RecipePreview): Promise<RecipePreview> {
     return await new this.previewModel(recipes).save();
+  }
+
+  // 동일한 thumbnail이 존재하는지 여부
+  async hasSameThumbnail(recipeId: Types.ObjectId, thumbnailUrl: string) {
+    return await this.recipeModel
+      .findOne({ _id: recipeId, thumbnail: thumbnailUrl })
+      .lean()
+      .exec();
+  }
+
+  // 레시피 ID로 thumbnail url 검색
+  async findThumbnail(recipeId: Types.ObjectId) {
+    const recipe = await this.recipeModel
+      .findOne({ _id: recipeId })
+      .select('thumbnail -_id')
+      .lean()
+      .exec();
+    return recipe.thumbnail;
+  }
+
+  // 레시피 수정
+  async updateRecipe(
+    userId: Types.ObjectId,
+    recipeId: Types.ObjectId,
+    data: EditRecipeDto,
+  ) {
+    const updatedRecipe = await this.recipeModel.findOneAndUpdate(
+      { _id: recipeId, writer: userId },
+      { ...data },
+    );
+
+    if (!updatedRecipe) {
+      throw new NotFoundException(
+        '레시피가 존재하지 않거나 수정 권한이 없습니다.',
+      );
+    }
+
+    const { introduce, ingredients, cooking_steps, ...rest } = data;
+    await this.previewModel.findOneAndUpdate(
+      { recipe_id: recipeId, writer: userId },
+      { ...rest },
+    );
+
+    return;
   }
 }

--- a/src/utils/dataTransform.utils.ts
+++ b/src/utils/dataTransform.utils.ts
@@ -1,5 +1,4 @@
 import { Types } from 'mongoose';
-import { v4 as uuidv4 } from 'uuid';
 
 export const stringToObjectId = (value: string): Types.ObjectId => {
   return new Types.ObjectId(value);
@@ -8,5 +7,3 @@ export const stringToObjectId = (value: string): Types.ObjectId => {
 export const decodeQueryParam = (param: string): string => {
   return decodeURIComponent(param);
 };
-
-export const getUUID = () => uuidv4();

--- a/src/utils/fileHandler.utils.ts
+++ b/src/utils/fileHandler.utils.ts
@@ -1,0 +1,5 @@
+import * as crypto from 'crypto';
+
+export const generateFileHash = (fileBuffer: Buffer): string => {
+  return crypto.createHash('sha256').update(fileBuffer).digest('hex');
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './dataTransform.utils';
+export * from './fileHandler.utils';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3156,6 +3156,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+crypto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
+  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -6113,11 +6118,6 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
-
-uuid@^11.0.2:
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.2.tgz#a8d68ba7347d051e7ea716cc8dcbbab634d66875"
-  integrity sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==
 
 uuid@^9.0.1:
   version "9.0.1"


### PR DESCRIPTION
## 🔍 PR 개요
레시피 수정 API 구현

## ✨ PR Type
<!--해당 항목에 X를 추가하세요.-->

- [X] 기능 구현(feat)
- [ ] 버그 수정(bugfix)
- [ ] 코드 스타일 변경(가독성 향상)
- [ ] 리팩토링(성능 최적화, 모듈화, 중복 코드 제거 등)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] 기타:

## 📋 변경 사항
- S3 fileName 생성하는 함수 변경(UUID -> HASH) S3에 업로드한 파일과 req로 받은 파일이 같은지 확인하기 위함
- uuid 삭제 및 crypto 설치

## 🛠 상세 작업 내역
- [X] path parameter id와 레시피의 _id 필드 값이 같고, userId가 writer와 같을 경우 레시피 수정 (preview도 같이 수정)
- [X] thumbnail 변경되었다면 S3에서 해당 파일 삭제 후 새 thumbnail 업데이트
- [X] AWS Service에 deleteFileFromS3 함수 추가

## ✅ 체크리스트
- [X] 레시피 수정 시 S3에서 파일이 업데이트 되는가? (중복이 발생하지 않는가?)
- [X] 수정 사항이 DB에 반영되었는가?

## 📸 스크린샷 (선택 사항)
<img width="846" alt="스크린샷 2024-11-02 오후 1 42 16" src="https://github.com/user-attachments/assets/7475d17e-cee5-4e8a-888b-9814f14ea3f5">

## ⚠️ 주의 사항
X

## 🔗 관련 이슈
- 관련된 이슈 번호를 참조하세요. Closes #43
