### PR TITLE
[FEAT] 라면 월드컵 이벤트 최종 선택 라면 카운트 API 추가

### DIFF
--- a/src/modules/events/events.module.ts
+++ b/src/modules/events/events.module.ts
@@ -1,7 +1,11 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { Ramen, RamenSchema, Worldcup, WorldcupSchema } from './schemas';
-import { WorldcupListService, WorldcupRamenInfoService } from './services';
+import {
+  WorldcupListService,
+  WorldcupRamenInfoService,
+  WorldcupSelectService,
+} from './services';
 import { WorldcupController } from './worldcup.controller';
 
 @Module({
@@ -12,6 +16,10 @@ import { WorldcupController } from './worldcup.controller';
     ]),
   ],
   controllers: [WorldcupController],
-  providers: [WorldcupListService, WorldcupRamenInfoService],
+  providers: [
+    WorldcupListService,
+    WorldcupRamenInfoService,
+    WorldcupSelectService,
+  ],
 })
 export class EventsModule {}

--- a/src/modules/events/services/index.ts
+++ b/src/modules/events/services/index.ts
@@ -1,2 +1,3 @@
 export * from './worldcup-list.service';
 export * from './worldcup-ramen-info.service';
+export * from './worldcup-select.service';

--- a/src/modules/events/services/worldcup-ramen-info.service.ts
+++ b/src/modules/events/services/worldcup-ramen-info.service.ts
@@ -8,6 +8,6 @@ export class WorldcupRamenInfoService {
   constructor(@InjectModel(Ramen.name) private ramenModel: Model<Ramen>) {}
 
   async getRamenInfo(id: string): Promise<Ramen> {
-    return await this.ramenModel.findOne({ _id: id }).exec();
+    return await this.ramenModel.findById(id).exec();
   }
 }

--- a/src/modules/events/services/worldcup-select.service.ts
+++ b/src/modules/events/services/worldcup-select.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Ramen, Worldcup } from '../schemas';
+import { Model } from 'mongoose';
+
+@Injectable()
+export class WorldcupSelectService {
+  constructor(
+    @InjectModel(Worldcup.name) private worldcupModel: Model<Worldcup>,
+    @InjectModel(Ramen.name) private ramenModel: Model<Ramen>,
+  ) {}
+
+  async selectRamen(id: string) {
+    await this.worldcupModel.findByIdAndUpdate(
+      '67244c5dbd13fe2b2e6c8136',
+      { $inc: { total_count: 1 } },
+      { new: true },
+    );
+
+    await this.ramenModel.findByIdAndUpdate(
+      id,
+      { $inc: { count: 1 } },
+      { new: true },
+    );
+  }
+}

--- a/src/modules/events/worldcup.controller.ts
+++ b/src/modules/events/worldcup.controller.ts
@@ -1,11 +1,16 @@
-import { Controller, Get, Param } from '@nestjs/common';
-import { WorldcupListService, WorldcupRamenInfoService } from './services';
+import { Body, Controller, Get, Param, Patch } from '@nestjs/common';
+import {
+  WorldcupListService,
+  WorldcupRamenInfoService,
+  WorldcupSelectService,
+} from './services';
 
 @Controller('events/worldcup')
 export class WorldcupController {
   constructor(
     private worldcupListService: WorldcupListService,
     private worldcupRamenInfoService: WorldcupRamenInfoService,
+    private worldcupSelectService: WorldcupSelectService,
   ) {}
 
   // 월드컵 이벤트 라면 리스트 조회(total_count 함께 제공)
@@ -20,5 +25,11 @@ export class WorldcupController {
   async getRamenInfo(@Param('id') id: string) {
     const data = await this.worldcupRamenInfoService.getRamenInfo(id);
     return { title: data.title, image: data.image, count: data.count };
+  }
+
+  // 월드컵 이벤트 최종 선택 라면 카운트
+  @Patch('/ramen')
+  async selectRamen(@Body('ramen_id') id: string) {
+    await this.worldcupSelectService.selectRamen(id);
   }
 }

--- a/src/modules/users/services/signoff.service.ts
+++ b/src/modules/users/services/signoff.service.ts
@@ -29,8 +29,8 @@ export class SignOffService {
     }
 
     await this.unlinkKakaoAccount(accessToken);
-    await this.userModel.findOneAndUpdate(
-      { _id: id },
+    await this.userModel.findByIdAndUpdate(
+      id,
       {
         access_token: '',
         is_deleted: true,

--- a/src/modules/users/services/signout.service.ts
+++ b/src/modules/users/services/signout.service.ts
@@ -29,8 +29,8 @@ export class SignOutService {
     }
 
     await this.logoutKakaoAccount(accessToken);
-    await this.userModel.findOneAndUpdate(
-      { _id: id },
+    await this.userModel.findByIdAndUpdate(
+      id,
       { access_token: '' },
       { new: true },
     );

--- a/src/modules/users/services/update-user.service.ts
+++ b/src/modules/users/services/update-user.service.ts
@@ -13,8 +13,8 @@ export class UpdateUserService {
     introduce: string,
     image: string,
   ) {
-    return await this.userModel.findOneAndUpdate(
-      { _id: id },
+    return await this.userModel.findByIdAndUpdate(
+      id,
       { nickname, introduce, profile_image: image },
       { new: true },
     );


### PR DESCRIPTION
## 🔍 PR 개요
라면 월드컵 이벤트 최종 선택 라면 카운트 PATCH API

## ✨ PR Type
<!--해당 항목에 X를 추가하세요.-->

- [x] 기능 구현(feat)
- [ ] 버그 수정(bugfix)
- [ ] 코드 스타일 변경(가독성 향상)
- [ ] 리팩토링(성능 최적화, 모듈화, 중복 코드 제거 등)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] 기타:

## 📋 변경 사항
- 파일 추가
- 코드 작성

## 🛠 상세 작업 내역
- [x] WorldcupController 코드 추가
- [x] WorldcupSelectService 추가

## ✅ 체크리스트
- [x] API 테스트

## 📸 스크린샷 (선택 사항)

<img width="736" alt="11-1" src="https://github.com/user-attachments/assets/bb0eec9f-4b1a-4467-8599-f81894dd65b1">

## ⚠️ 주의 사항
x

## 🔗 관련 이슈
- 관련된 이슈 번호 #39
