### PR TITLE
[FEAT] 레시피 삭제 API 구현

### DIFF
--- a/src/modules/recipes/recipes.controller.ts
+++ b/src/modules/recipes/recipes.controller.ts
@@ -2,6 +2,7 @@ import { stringToObjectId } from 'src/utils';
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   Post,
@@ -77,7 +78,25 @@ export class RecipesController {
     @Body() data: ReqRecipeDto,
   ) {
     const recipeData: EditRecipeDto = { ...data, thumbnail };
-    await this.recipesService.updateRecipe(userId, recipeId, recipeData);
+    await this.recipesService.updateRecipe(
+      stringToObjectId(userId),
+      stringToObjectId(recipeId),
+      recipeData,
+    );
+    return;
+  }
+
+  // 레시피 삭제
+  @UseGuards(AuthGuard)
+  @Delete(':recipe_id')
+  async deleteRecipe(
+    @UserIdParam() userId: UserId,
+    @Param('recipe_id') recipeId: string,
+  ) {
+    await this.recipesService.deleteRecipe(
+      stringToObjectId(userId),
+      stringToObjectId(recipeId),
+    );
     return;
   }
 }

--- a/src/modules/recipes/recipes.repository.ts
+++ b/src/modules/recipes/recipes.repository.ts
@@ -1,8 +1,12 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, SortOrder, Types } from 'mongoose';
 import { RecipePreview } from './schema/recipe-preview.schema';
-import { Recipe, RecipeDocument } from './schema/recipe.schema';
+import { Recipe } from './schema/recipe.schema';
 import { User } from '@modules/users/schemas';
 import { WriterDto } from './dto/res-recipes.dto';
 import { EditRecipeDto } from './dto';
@@ -13,15 +17,30 @@ export interface RecipeRepository {
     sortOption: object,
     limit: number,
   ): Promise<RecipePreview[]>;
-  findRecipes(
+  findRecipesByKeyword(
     keyword: string,
-    dbQuery: object,
+    dbQuery: { created_at: { $lt: number } } | {},
     limit: number,
   ): Promise<RecipePreview[]>;
-  findUser(
+  findUser(userId: Types.ObjectId): Promise<WriterDto | null>;
+  findRecipeById(recipeId: Types.ObjectId): Promise<Recipe>;
+  checkRecipeExists(
     userId: Types.ObjectId,
-  ): Promise<{ nickname: string; profile_image: string } | null>;
+    recipeId: Types.ObjectId,
+  ): Promise<boolean>;
   insertRecipe(recipes: Recipe): Promise<Recipe>;
+  insertPreview(recipes: RecipePreview): Promise<RecipePreview>;
+  hasSameThumbnail(
+    recipeId: Types.ObjectId,
+    thumbnailUrl: string,
+  ): Promise<boolean>;
+  findThumbnail(recipeId: Types.ObjectId): Promise<string>;
+  updateRecipe(
+    userId: Types.ObjectId,
+    recipeId: Types.ObjectId,
+    data: EditRecipeDto,
+  ): Promise<void>;
+  deleteRecipe(userId: Types.ObjectId, recipeId: Types.ObjectId): Promise<void>;
 }
 
 @Injectable()
@@ -32,6 +51,7 @@ export class RecipeMongoRepository implements RecipeRepository {
     @InjectModel(User.name) private userModel: Model<User>,
   ) {}
 
+  // 레시피 목록 필터링
   async filteredRecipes(
     dbQuery: object,
     sortOption: { [key: string]: SortOrder },
@@ -45,7 +65,8 @@ export class RecipeMongoRepository implements RecipeRepository {
       .exec();
   }
 
-  async findRecipes(
+  // 키워드로 레시피 검색
+  async findRecipesByKeyword(
     keyword: string,
     dbQuery: { created_at: { $lt: number } } | {},
     limit: number,
@@ -63,6 +84,7 @@ export class RecipeMongoRepository implements RecipeRepository {
       .exec();
   }
 
+  // userId로 유저 정보 반환
   async findUser(userId: Types.ObjectId): Promise<WriterDto | null> {
     return await this.userModel
       .findOne(
@@ -73,8 +95,31 @@ export class RecipeMongoRepository implements RecipeRepository {
       .exec();
   }
 
-  async findRecipeDetails(recipeId: Types.ObjectId): Promise<Recipe> {
-    return await this.recipeModel.findOne({ _id: recipeId }).lean().exec();
+  // 레시피 상세 불러오기
+  async findRecipeById(recipeId: Types.ObjectId): Promise<Recipe> {
+    const recipe = await this.recipeModel
+      .findOne({ _id: recipeId })
+      .lean()
+      .exec();
+    if (!recipe) throw new NotFoundException('레시피가 존재하지 않습니다.');
+    return recipe;
+  }
+
+  // userId와 recipeId가 일치하는 레시피 존재 여부 확인
+  async checkRecipeExists(
+    userId: Types.ObjectId,
+    recipeId: Types.ObjectId,
+  ): Promise<boolean> {
+    const recipeExists = await this.recipeModel.exists({
+      _id: recipeId,
+      writer: userId,
+    });
+
+    if (!recipeExists) {
+      throw new NotFoundException('레시피가 존재하지 않거나 권한이 없습니다.');
+    }
+
+    return recipeExists !== null;
   }
 
   async insertRecipe(recipes: Recipe): Promise<Recipe> {
@@ -86,20 +131,25 @@ export class RecipeMongoRepository implements RecipeRepository {
   }
 
   // 동일한 thumbnail이 존재하는지 여부
-  async hasSameThumbnail(recipeId: Types.ObjectId, thumbnailUrl: string) {
-    return await this.recipeModel
-      .findOne({ _id: recipeId, thumbnail: thumbnailUrl })
-      .lean()
-      .exec();
+  async hasSameThumbnail(
+    recipeId: Types.ObjectId,
+    thumbnailUrl: string,
+  ): Promise<boolean> {
+    const exists = await this.recipeModel.exists({
+      _id: recipeId,
+      thumbnail: thumbnailUrl,
+    });
+    return exists != null;
   }
 
   // 레시피 ID로 thumbnail url 검색
-  async findThumbnail(recipeId: Types.ObjectId) {
+  async findThumbnail(recipeId: Types.ObjectId): Promise<string> {
     const recipe = await this.recipeModel
       .findOne({ _id: recipeId })
       .select('thumbnail -_id')
       .lean()
       .exec();
+    if (!recipe) throw new NotFoundException('레시피를 찾을 수 없습니다.');
     return recipe.thumbnail;
   }
 
@@ -108,16 +158,14 @@ export class RecipeMongoRepository implements RecipeRepository {
     userId: Types.ObjectId,
     recipeId: Types.ObjectId,
     data: EditRecipeDto,
-  ) {
+  ): Promise<void> {
     const updatedRecipe = await this.recipeModel.findOneAndUpdate(
       { _id: recipeId, writer: userId },
       { ...data },
     );
 
     if (!updatedRecipe) {
-      throw new NotFoundException(
-        '레시피가 존재하지 않거나 수정 권한이 없습니다.',
-      );
+      throw new ForbiddenException('레시피의 수정 권한이 없습니다.');
     }
 
     const { introduce, ingredients, cooking_steps, ...rest } = data;
@@ -125,7 +173,22 @@ export class RecipeMongoRepository implements RecipeRepository {
       { recipe_id: recipeId, writer: userId },
       { ...rest },
     );
+    return;
+  }
 
+  // 레시피 삭제
+  async deleteRecipe(
+    userId: Types.ObjectId,
+    recipeId: Types.ObjectId,
+  ): Promise<void> {
+    await this.recipeModel.findOneAndDelete({
+      _id: recipeId,
+      writer: userId,
+    });
+    await this.previewModel.findOneAndDelete({
+      recipe_id: recipeId,
+      writer: userId,
+    });
     return;
   }
 }


### PR DESCRIPTION
## 🔍 PR 개요
레시피 삭제 API 구현 및 recipe service 리팩토링

## ✨ PR Type
<!--해당 항목에 X를 추가하세요.-->

- [X] 기능 구현(feat)
- [ ] 버그 수정(bugfix)
- [ ] 코드 스타일 변경(가독성 향상)
- [X] 리팩토링(성능 최적화, 모듈화, 중복 코드 제거 등)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] 기타:

## 📋 변경 사항
X

## 🛠 상세 작업 내역
- [X] 레시피 삭제 API(DELETE /recipes/:recipe_id) 요청 시 recipe collection, preview collection에서 해당 레시피 삭제
- [X] S3에서 thumbnail 삭제

## ✅ 체크리스트
- [X] 코드가 예상대로 동작하는지 확인
- [X] 관련 테스트가 성공적으로 통과했는지 확인
- [X] 문서가 최신 상태로 유지되었는지 확인 (예: API 문서, README)

## 📸 스크린샷 (선택 사항)
<img width="846" alt="스크린샷 2024-11-03 오전 12 59 23" src="https://github.com/user-attachments/assets/a40ded64-bf40-455d-87b4-829179c4099e">

## ⚠️ 주의 사항
X

## 🔗 관련 이슈
- 관련된 이슈 번호를 참조하세요. 예: Closes #47
