### PR TITLE
[FEAT] 북마크 레시피들의 프리뷰 정보 조회 API 추가

### DIFF
--- a/src/modules/recipes/recipes.service.ts
+++ b/src/modules/recipes/recipes.service.ts
@@ -52,7 +52,10 @@ export class RecipesService {
   // S3에서 기존 파일 삭제
   private async removeThumbFromS3(recipeId: Types.ObjectId) {
     const prevThumbnail = await this.recipeRepository.findThumbnail(recipeId);
-    await this.awsService.deleteFileFromS3(prevThumbnail.split('/').pop());
+    await this.awsService.deleteFileFromS3(
+      prevThumbnail.split('/').pop(),
+      'recipes',
+    );
   }
 
   // 레시피 목록 조회
@@ -193,7 +196,10 @@ export class RecipesService {
 
     if (hasSameThumbnail) updateData = rest;
     else {
-      const imageUrl = await this.awsService.uploadImgToS3(data.thumbnail);
+      const imageUrl = await this.awsService.uploadImgToS3(
+        data.thumbnail,
+        'recipes',
+      );
       await this.removeThumbFromS3(recipeId);
       updateData = { ...rest, thumbnail: imageUrl };
     }

--- a/src/modules/users/services/bookmark.service.ts
+++ b/src/modules/users/services/bookmark.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { User } from '../schemas';
+import { Model } from 'mongoose';
+import { RecipePreview } from '@modules/recipes';
+
+@Injectable()
+export class BookmarkService {
+  constructor(
+    @InjectModel(User.name) private userModel: Model<User>,
+    @InjectModel(RecipePreview.name)
+    private recipePreviewModel: Model<RecipePreview>,
+  ) {}
+
+  async getUserBookmark(id: string) {
+    const user = await this.userModel.findById(id);
+    const recipe_preview = await this.recipePreviewModel.find({
+      recipe_id: { $in: user.bookmark },
+    });
+    return { recipe_preview };
+  }
+}

--- a/src/modules/users/services/index.ts
+++ b/src/modules/users/services/index.ts
@@ -4,3 +4,4 @@ export * from './signup.service';
 export * from './signout.service';
 export * from './update-user.service';
 export * from './signoff.service';
+export * from './bookmark.service';

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -22,6 +22,7 @@ import {
   SignOutService,
   UpdateUserService,
   SignOffService,
+  BookmarkService,
 } from './services';
 import { AuthGuard } from '@auth/auth.guard';
 import { Request, Response } from 'express';
@@ -40,6 +41,7 @@ export class UsersController {
     private updateUserService: UpdateUserService,
     private signOffService: SignOffService,
     private awsService: AWSService,
+    private bookmarkService: BookmarkService,
   ) {}
 
   // 카카오 로그인 url
@@ -222,5 +224,13 @@ export class UsersController {
     const id = req.user.userId;
     await this.signOffService.signOff(id);
     res.clearCookie('token');
+  }
+
+  // 북마크 레시피 조회
+  @Get('/bookmark')
+  @UseGuards(AuthGuard)
+  async getUserBookmark(@Req() req: Request) {
+    const id = req.user.userId;
+    return await this.bookmarkService.getUserBookmark(id);
   }
 }

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -10,13 +10,18 @@ import {
   SignOutService,
   UpdateUserService,
   SignOffService,
+  BookmarkService,
 } from './services';
 import { AuthModule } from '@auth/auth.module';
 import { AWSModule } from '@modules/aws/aws.module';
+import { PreviewSchema, RecipePreview } from '@modules/recipes';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
+    MongooseModule.forFeature([
+      { name: RecipePreview.name, schema: PreviewSchema },
+    ]),
     HttpModule,
     AuthModule,
     AWSModule,
@@ -29,6 +34,7 @@ import { AWSModule } from '@modules/aws/aws.module';
     SignOutService,
     UpdateUserService,
     SignOffService,
+    BookmarkService,
   ],
 })
 export class UsersModule {}


### PR DESCRIPTION
## 🔍 PR 개요
마이페이지에 표시될 나의 북마크한 레시피들의 프리뷰 정보들을 조회할 수 있는 API

## ✨ PR Type
<!--해당 항목에 X를 추가하세요.-->

- [x] 기능 구현(feat)
- [ ] 버그 수정(bugfix)
- [ ] 코드 스타일 변경(가독성 향상)
- [ ] 리팩토링(성능 최적화, 모듈화, 중복 코드 제거 등)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] 기타:

## 📋 변경 사항
- 파일 추가
- 코드 추가

## 🛠 상세 작업 내역
- [x] users의 controller, module 수정
- [x] bookmark service 추가

## ✅ 체크리스트
- [x] API 테스트

## 📸 스크린샷 (선택 사항)

<img width="746" alt="북마크" src="https://github.com/user-attachments/assets/a8016c87-e379-46ec-99a1-06bc9409a5df">

## ⚠️ 주의 사항
X

## 🔗 관련 이슈
- 관련된 이슈 번호 #58
