### PR TITLE
[FEAT] 레시피 등록, 삭제 API와 userModel 연결

### DIFF
--- a/src/modules/aws/aws.service.ts
+++ b/src/modules/aws/aws.service.ts
@@ -71,8 +71,8 @@ export class AWSService {
     return `https://${this.awsS3BucketName}.s3.${this.awsRegion}.amazonaws.com/ramens/${fileName}`;
   }
 
-  getS3Url(fileName: string): string {
-    return `https://${this.awsS3BucketName}.s3.${this.awsRegion}.amazonaws.com/${fileName}`;
+  getS3Url(fileName: string, folder: string): string {
+    return `https://${this.awsS3BucketName}.s3.${this.awsRegion}.amazonaws.com/${folder}/${fileName}`;
   }
 
   async deleteFileFromS3(fileName: string, folder: string) {

--- a/src/modules/recipes/recipes.controller.ts
+++ b/src/modules/recipes/recipes.controller.ts
@@ -92,7 +92,9 @@ export class RecipesController {
     @UserIdParam() userId: UserId,
     @Param('recipe_id') recipeId: string,
   ) {
-    await this.recipesService.deleteRecipe(userId, stringToObjectId(recipeId));
-    return;
+    return await this.recipesService.deleteRecipe(
+      userId,
+      stringToObjectId(recipeId),
+    );
   }
 }

--- a/src/modules/recipes/recipes.service.ts
+++ b/src/modules/recipes/recipes.service.ts
@@ -52,7 +52,10 @@ export class RecipesService {
   // S3에서 기존 파일 삭제
   private async removeThumbFromS3(recipeId: Types.ObjectId) {
     const prevThumbnail = await this.recipeRepository.findThumbnail(recipeId);
-    await this.awsService.deleteFileFromS3(prevThumbnail.split('/').pop());
+    await this.awsService.deleteFileFromS3(
+      prevThumbnail.split('/').pop(),
+      'recipes',
+    );
   }
 
   // 레시피 목록 조회
@@ -139,6 +142,7 @@ export class RecipesService {
   async getRecipeDetails(recipeId: Types.ObjectId) {
     const recipe = await this.recipeRepository.findRecipeById(recipeId);
     const writerInfo = await this.recipeRepository.findUser(recipe.writer);
+
     return { ...recipe, writer: writerInfo };
   }
 
@@ -148,16 +152,17 @@ export class RecipesService {
       data.thumbnail,
       'recipes',
     );
-    const createdRecipe = {
+    const createdRecipe = await this.recipeRepository.saveRecipe({
       ...data,
       thumbnail: imageUrl,
       tags: data.tags.map((id) => stringToObjectId(id)),
       writer: userId,
       likes: 0,
       comments: [],
-    };
+    });
 
-    return await this.recipeRepository.insertRecipe(createdRecipe);
+    await this.recipeRepository.saveMyRecipe(userId, createdRecipe._id);
+    return createdRecipe;
   }
 
   // 레시피 프리뷰 등록
@@ -173,7 +178,7 @@ export class RecipesService {
       created_at,
     };
 
-    return await this.recipeRepository.insertPreview(createdRecipe);
+    return await this.recipeRepository.savePreview(createdRecipe);
   }
 
   // 레시피 수정
@@ -183,7 +188,7 @@ export class RecipesService {
     data: EditRecipeDto,
   ) {
     const hash = generateFileHash(data.thumbnail.buffer);
-    const s3Url = this.awsService.getS3Url(hash);
+    const s3Url = this.awsService.getS3Url(hash, 'recipes');
     const hasSameThumbnail = await this.recipeRepository.hasSameThumbnail(
       recipeId,
       s3Url,
@@ -193,7 +198,10 @@ export class RecipesService {
 
     if (hasSameThumbnail) updateData = rest;
     else {
-      const imageUrl = await this.awsService.uploadImgToS3(data.thumbnail);
+      const imageUrl = await this.awsService.uploadImgToS3(
+        data.thumbnail,
+        'recipes',
+      );
       await this.removeThumbFromS3(recipeId);
       updateData = { ...rest, thumbnail: imageUrl };
     }
@@ -211,8 +219,11 @@ export class RecipesService {
     recipeId: Types.ObjectId,
   ): Promise<void> {
     await this.recipeRepository.checkRecipeExists(recipeId, userId);
-    await this.removeThumbFromS3(recipeId);
-    await this.recipeRepository.deleteRecipe(userId, recipeId);
+    await Promise.all([
+      this.removeThumbFromS3(recipeId),
+      this.recipeRepository.deleteRecipe(userId, recipeId),
+      this.recipeRepository.deleteMyRecipe(userId, recipeId),
+    ]);
     return;
   }
 }


### PR DESCRIPTION
## 🔍 PR 개요
레시피 등록, 삭제 API 요청 시 users의 my_recipes에 recipe_id 추가 또는 삭제

## ✨ PR Type
<!--해당 항목에 X를 추가하세요.-->

- [X] 기능 구현(feat)
- [ ] 버그 수정(bugfix)
- [ ] 코드 스타일 변경(가독성 향상)
- [ ] 리팩토링(성능 최적화, 모듈화, 중복 코드 제거 등)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] 기타:

## 📋 변경 사항
- AWSService getS3Url()의 return url 경로 수정

## 🛠 상세 작업 내역
- [X] 레시피 등록 시 해당 레시피 ID my_recipes에 추가
- [X] 레시피 삭제 시 해당 레시피 ID my_recipes에서 삭제
- [X] 레시피 삭제 병렬 처리

## ✅ 체크리스트
- [X] 코드가 예상대로 동작하는지 확인
- [X] 관련 테스트가 성공적으로 통과했는지 확인
- [X] 문서가 최신 상태로 유지되었는지 확인 (예: API 문서, README)

## 📸 스크린샷 (선택 사항)
X

## ⚠️ 주의 사항
X

## 🔗 관련 이슈
- 관련된 이슈 번호를 참조하세요. Closes #60
