### PR TITLE
[FEAT] 레시피 좋아요 API 구현

### DIFF
--- a/src/modules/comments/comments.controller.ts
+++ b/src/modules/comments/comments.controller.ts
@@ -17,18 +17,6 @@ import { UserId, UserIdParam } from '@common/decorators';
 import { CommentParamsDto, ReqCommentDto } from './dto';
 import { stringToObjectId } from 'src/utils';
 
-export class NoContentException extends HttpException {
-  constructor(message: string) {
-    super(
-      {
-        status: HttpStatus.NO_CONTENT,
-        message: message || 'No Content',
-      },
-      HttpStatus.NO_CONTENT,
-    );
-  }
-}
-
 @Controller('recipes/:recipe_id/comments')
 export class CommentsController {
   constructor(private readonly commentsService: CommentsService) {}

--- a/src/modules/recipes/dto/create-recipe.dto.ts
+++ b/src/modules/recipes/dto/create-recipe.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsString, ValidateNested } from 'class-validator';
+import { IsArray, IsNotEmpty, IsString, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class IngredientDto {
@@ -36,4 +36,11 @@ export class CreateRecipeDto extends ReqRecipeDto {
 
 export class EditRecipeDto extends ReqRecipeDto {
   thumbnail?: Express.Multer.File;
+}
+
+export type ToggleLikeAction = 'add' | 'remove';
+
+export class ToggleLikeDto {
+  @IsNotEmpty()
+  action: ToggleLikeAction;
 }

--- a/src/modules/recipes/recipes.controller.ts
+++ b/src/modules/recipes/recipes.controller.ts
@@ -22,6 +22,7 @@ import {
   CreateRecipeDto,
   EditRecipeDto,
   ReqRecipeDto,
+  ToggleLikeDto,
 } from './dto/create-recipe.dto';
 
 @Controller('recipes')
@@ -95,6 +96,21 @@ export class RecipesController {
     return await this.recipesService.deleteRecipe(
       userId,
       stringToObjectId(recipeId),
+    );
+  }
+
+  // 레시피 좋아요 추가/취소
+  @UseGuards(AuthGuard)
+  @Post(':recipe_id/like')
+  async toggleLike(
+    @UserIdParam() userId: UserId,
+    @Param('recipe_id') recipeId: string,
+    @Body() toggleLikeDto: ToggleLikeDto,
+  ) {
+    return await this.recipesService.toggleLike(
+      userId,
+      stringToObjectId(recipeId),
+      toggleLikeDto.action,
     );
   }
 }

--- a/src/modules/recipes/recipes.service.ts
+++ b/src/modules/recipes/recipes.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { RecipeRepository } from './recipes.repository';
 import { AWSService } from '@modules/aws/aws.service';
 import { UserId } from '@common/decorators';
@@ -16,6 +16,7 @@ import {
   PaginationRecipesDto,
   ResRecipesDto,
   SearchRecipesDto,
+  ToggleLikeAction,
 } from './dto';
 import { Types } from 'mongoose';
 
@@ -225,5 +226,18 @@ export class RecipesService {
       this.recipeRepository.deleteMyRecipe(userId, recipeId),
     ]);
     return;
+  }
+
+  // 레시피 좋아요
+  async toggleLike(
+    userId: Types.ObjectId,
+    recipeId: Types.ObjectId,
+    action: ToggleLikeAction,
+  ): Promise<{ likes: number }> {
+    if (action === 'add') {
+      return await this.recipeRepository.addLike(userId, recipeId);
+    } else if (action === 'remove') {
+      return await this.recipeRepository.removeLike(userId, recipeId);
+    } else throw new BadRequestException('유효하지 않은 요청입니다.');
   }
 }


### PR DESCRIPTION
## 🔍 PR 개요
레시피 좋아요 추가/취소 API 구현

## ✨ PR Type
<!--해당 항목에 X를 추가하세요.-->

- [X] 기능 구현(feat)
- [ ] 버그 수정(bugfix)
- [ ] 코드 스타일 변경(가독성 향상)
- [ ] 리팩토링(성능 최적화, 모듈화, 중복 코드 제거 등)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] 기타:

## 📋 변경 사항
- comments controller 필요 없는 코드 삭제
- 새로운 API 엔드포인트 추가

## 🛠 상세 작업 내역
- [X] 레시피 좋아요 추가 시 해당 레시피 likes 수 증가 및 유저 likes에 recipe_id 추가
- [X] 레시피 좋아요 취소 시 해당 레시피 likes 수 감소 및 유저 likes에 recipe_id 제거
- [X] 변경된 좋아요 수 반환

## ✅ 체크리스트
- [X] 코드가 예상대로 동작하는지 확인
- [X] 관련 테스트가 성공적으로 통과했는지 확인
- [X] 문서가 최신 상태로 유지되었는지 확인 (예: API 문서, README)

## 📸 스크린샷 (선택 사항)
<img width="850" alt="스크린샷 2024-11-04 오후 4 31 47" src="https://github.com/user-attachments/assets/87b3bd43-57ca-47bc-8d57-4a3273def480">

## ⚠️ 주의 사항
X

## 🔗 관련 이슈
- 관련된 이슈 번호를 참조하세요. Closes #71
