### PR TITLE
[FIX] 로그인, 회원가입 API 수정

### DIFF
--- a/src/modules/aws/aws.service.ts
+++ b/src/modules/aws/aws.service.ts
@@ -40,6 +40,7 @@ export class AWSService {
       Key: `${folder}/${fileName}`,
       Body: file.buffer,
       ContentType: `image/${ext}`,
+      ACL: 'bucket-owner-full-control',
     });
 
     await this.s3Client.send(uploadParams);

--- a/src/modules/users/dtos/create-user.dto.ts
+++ b/src/modules/users/dtos/create-user.dto.ts
@@ -3,12 +3,12 @@ import { IsString, IsNotEmpty } from 'class-validator';
 export class CreateUserDto {
   @IsString()
   @IsNotEmpty()
+  email: string;
+
+  @IsString()
+  @IsNotEmpty()
   nickname: string;
 
   @IsString()
   introduce: string;
-
-  @IsString()
-  @IsNotEmpty()
-  code: string;
 }

--- a/src/modules/users/services/signin.service.ts
+++ b/src/modules/users/services/signin.service.ts
@@ -2,10 +2,50 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { User } from '../schemas';
 import { Model } from 'mongoose';
+import { ConfigService } from '@nestjs/config';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
 
 @Injectable()
 export class SignInService {
-  constructor(@InjectModel(User.name) private userModel: Model<User>) {}
+  constructor(
+    private configService: ConfigService,
+    private httpService: HttpService,
+    @InjectModel(User.name) private userModel: Model<User>,
+  ) {}
+
+  async getCode() {}
+
+  async getKakaoUser(code: string) {
+    const access_token = await this.getKakaoAccessToken(code);
+    const email = await this.getKakaoUserEmail(access_token);
+    return { email, access_token };
+  }
+
+  private async getKakaoAccessToken(code: string): Promise<string> {
+    const requestUrl = 'https://kauth.kakao.com/oauth/token';
+    const params = {
+      grant_type: 'authorization_code',
+      client_id: this.configService.get('kakaoRestAPIKey'),
+      redirect_uri: this.configService.get('kakaoRedirectUri'),
+      code,
+    };
+
+    const response = await firstValueFrom(
+      this.httpService.post(requestUrl, null, { params }),
+    );
+    return response.data.access_token;
+  }
+
+  private async getKakaoUserEmail(accessToken: string): Promise<string> {
+    const userInfoUrl = 'https://kapi.kakao.com/v2/user/me';
+    const headers = { Authorization: `Bearer ${accessToken}` };
+
+    const response = await firstValueFrom(
+      this.httpService.get(userInfoUrl, { headers }),
+    );
+    return response.data.kakao_account.email;
+  }
 
   async saveToken(email: string, access_token: string) {
     const updatedUser = await this.userModel.findOneAndUpdate(


### PR DESCRIPTION
## 🔍 PR 개요
불필요한 카카오 인가코드 다수 요청으로 인해 발생하는 500에러를 피하기 위해 로그인과 회원가입 API의 요청과 응답을 수정

## ✨ PR Type
<!--해당 항목에 X를 추가하세요.-->

- [X] 기능 구현(feat)
- [ ] 버그 수정(bugfix)
- [ ] 코드 스타일 변경(가독성 향상)
- [ ] 리팩토링(성능 최적화, 모듈화, 중복 코드 제거 등)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [X] 기타:

## 📋 변경 사항
- 코드 수정

## 🛠 상세 작업 내역
- [x] users controller 수정
- [x] signin service 수정
- [x] signup service 수정

## ✅ 체크리스트
- [x] API 테스트

## 📸 스크린샷 (선택 사항)

로그인 실패
<img width="659" alt="로그인실패" src="https://github.com/user-attachments/assets/c76c4872-15f8-46da-b95a-48747d16fd78">

로그인 성공
<img width="656" alt="로그인 성공" src="https://github.com/user-attachments/assets/1d569dd6-532f-41c9-a7c7-bdfb4b8a3b9e">

회원가입 성공
<img width="658" alt="회원가입1" src="https://github.com/user-attachments/assets/a7c394ae-cba3-4571-a1af-2af2e006464d">

이미 존재하는 사용자
<img width="660" alt="회원가입2" src="https://github.com/user-attachments/assets/b4ad9e5f-b16d-4870-9092-885b5933587e">

이미 사용하고 있는 닉네임
<img width="659" alt="회원가입3" src="https://github.com/user-attachments/assets/366e8648-a205-4fc9-a3e7-365b26895fc2">

## ⚠️ 주의 사항
X

## 🔗 관련 이슈
- 관련된 이슈 번호 #87
